### PR TITLE
Other: Java 8 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,9 @@ repositories {
     mavenCentral()
 }
 
+sourceCompatibility = '1.8'
+targetCompatibility = '1.8'
+
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.19.0'

--- a/src/main/java/com/dynatrace/dynahist/AbstractHistogram.java
+++ b/src/main/java/com/dynatrace/dynahist/AbstractHistogram.java
@@ -232,7 +232,7 @@ abstract class AbstractHistogram implements Histogram {
 
     @Override
     public Iterator<Bin> iterator() {
-      return new Iterator<>() {
+      return new Iterator<Bin>() {
         private BinIterator it = null;
 
         @Override

--- a/src/test/java/com/dynatrace/dynahist/layout/LayoutTestUtil.java
+++ b/src/test/java/com/dynatrace/dynahist/layout/LayoutTestUtil.java
@@ -42,7 +42,7 @@ public final class LayoutTestUtil {
   private static Condition<Integer> validNaNIndex(Layout layout) {
     int underFlowIndex = layout.getUnderflowBinIndex();
     int overFlowIndex = layout.getUnderflowBinIndex();
-    return new Condition<>() {
+    return new Condition<Integer>() {
       @Override
       public boolean matches(Integer value) {
         return value >= overFlowIndex || value <= underFlowIndex;
@@ -52,7 +52,7 @@ public final class LayoutTestUtil {
 
   private static Condition<Integer> validPosInfIndex(Layout layout) {
     int overFlowIndex = layout.getUnderflowBinIndex();
-    return new Condition<>() {
+    return new Condition<Integer>() {
       @Override
       public boolean matches(Integer value) {
         return value >= overFlowIndex;
@@ -62,7 +62,7 @@ public final class LayoutTestUtil {
 
   private static Condition<Integer> validNegInfIndex(Layout layout) {
     int underFlowIndex = layout.getUnderflowBinIndex();
-    return new Condition<>() {
+    return new Condition<Integer>() {
       @Override
       public boolean matches(Integer value) {
         return value <= underFlowIndex;


### PR DESCRIPTION
### <strong>Pull Request</strong>

Java 8 is is still widely used as a least common denominator for libraries to ensure greatest possible compatibility.

Making this project compatible was trivial. Upgrading to 11 could be re-visited in case particular features are required.

<!-- Other (if none of the above apply) -->

#### Checklist

- [x] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] `gradle build` passes locally with my changes