### PR TITLE
use Temurin JDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/sonarqube-analysis.yml
+++ b/.github/workflows/sonarqube-analysis.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 11
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Set up Python
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
### <strong>Pull Request</strong>


chore:  replace AdoptOpenJDK with Temurin JDK

AdoptOpenJDK is obsolete.


#### Checklist

- [ ] I have read the CONTRIBUTING doc and I follow the PR guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] `gradle build` passes locally with my changes
