### PR TITLE
throw instead of hanging on incomplete compressed input

### DIFF
--- a/src/main/java/com/dynatrace/dynahist/serialization/SerializationUtil.java
+++ b/src/main/java/com/dynatrace/dynahist/serialization/SerializationUtil.java
@@ -309,7 +309,11 @@ public final class SerializationUtil {
       inflater.setInput(data);
       byte[] buffer = new byte[1024];
       while (!inflater.finished()) {
-        outputStream.write(buffer, 0, inflater.inflate(buffer));
+        int numInflatedBytes = inflater.inflate(buffer);
+        if (numInflatedBytes == 0 && (inflater.needsInput() || inflater.needsDictionary())) {
+          throw new DataFormatException("Compressed data is incomplete.");
+        }
+        outputStream.write(buffer, 0, numInflatedBytes);
       }
       return outputStream.toByteArray();
     }

--- a/src/test/java/com/dynatrace/dynahist/serialization/SerializationUtilTest.java
+++ b/src/test/java/com/dynatrace/dynahist/serialization/SerializationUtilTest.java
@@ -26,6 +26,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
 import java.util.zip.DataFormatException;
 import org.junit.jupiter.api.Test;
 
@@ -194,5 +196,29 @@ public class SerializationUtilTest {
             IOException.class, () -> SerializationUtil.checkSerialVersion((byte) 145, (byte) 211));
     assertThat(exception.getMessage())
         .isEqualTo("Incompatible serial versions! Expected version 145 but was 211.");
+  }
+
+  @Test
+  void testReadCompressedWithEmptyInput() {
+    Layout layout = LogQuadraticLayout.create(1e-5, 1e-2, -1e6, 1e6);
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(5),
+        () ->
+            assertThrows(
+                DataFormatException.class,
+                () -> SerializationUtil.readCompressedAsDynamic(layout, new byte[0])));
+  }
+
+  @Test
+  void testReadCompressedWithTruncatedInput() throws IOException {
+    Layout layout = LogQuadraticLayout.create(1e-5, 1e-2, -1e6, 1e6);
+    Histogram histogram = Histogram.createDynamic(layout).addValue(3.5).addValue(7.25);
+    byte[] truncated = Arrays.copyOf(SerializationUtil.writeCompressed(histogram), 3);
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(5),
+        () ->
+            assertThrows(
+                DataFormatException.class,
+                () -> SerializationUtil.readCompressedAsStatic(layout, truncated)));
   }
 }


### PR DESCRIPTION
`SerializationUtil.decompress` drives the inflater with only `finished()` as the stop condition:

```java
Inflater inflater = new Inflater();
inflater.setInput(data);
byte[] buffer = new byte[1024];
while (!inflater.finished()) {
  outputStream.write(buffer, 0, inflater.inflate(buffer));
}
```

`inflate` returns 0 when it needs more input, and `finished()` stays false in that case, so an empty or truncated payload makes this spin at full CPU forever. it never throws the `DataFormatException` the method already declares, so a caller cannot recover either

it is reachable from three public entry points that take a caller-supplied array: `readCompressedAsStatic`, `readCompressedAsDynamic` and `readCompressedAsPreprocessed`. a short read from a socket or a partially written file is enough

worth noting: random bytes do throw, because the zlib header check catches them. the hang needs either an empty array or a stream that starts correctly and is cut short, for example `Arrays.copyOf(writeCompressed(h), 3)`

## changes

bail out with `DataFormatException` when the inflater made no progress and is waiting for input or a dictionary

## testing

two tests, one with an empty array and one with a truncated stream, both wrapped in `assertTimeoutPreemptively` since a plain `assertThrows` would wedge the runner. both fail with a 5 second timeout before the change and pass after

I could not use gradle locally, its toolchain wants a jdk newer than I have, so I compiled the sources with javac and ran the test class through the junit console launcher: 9 tests pass with the change, 7 pass and 2 time out without it. formatting checked against google-java-format 1.34.1, the version spotless pins